### PR TITLE
Add badges for the build pipeline

### DIFF
--- a/.github/workflows/pdflatex.yml
+++ b/.github/workflows/pdflatex.yml
@@ -1,4 +1,4 @@
-name: Build PDFs of the LaTeX
+name: LaTeX build
 on:
   push:
     branches-ignore:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # hut23-linear-algebra
 
+[![LaTeX build](../../actions/workflows/pdflatex.yml/badge.svg)](../../actions/workflows/pdflatex.yml)
+[![All the maths](https://img.shields.io/badge/PDF-All_the_maths-orange.svg?style=flat)](../gh-action-result/pdflatex/working/all-the-maths-we-know.pdf)
+[![All the rules](https://img.shields.io/badge/PDF-All_the_rules-orange.svg?style=flat)](../gh-action-result/pdflatex/working/all-the-rules-we-know.pdf)
+
 Repository for the Linear Algebra reading group. Some material in this
 repo uses $\LaTeX$ (and/or Makefiles). On a mac, use `brew install mactex`.
 


### PR DESCRIPTION
Adds little badges for the pipeline status and links to the resulting PDFs.

The result looks like this: https://github.com/llewelld/hut23-linear-algebra/tree/badges