### PR TITLE
Update rules to match fourth edition numbering

### DIFF
--- a/reference/all-the-rules-we-know.tex
+++ b/reference/all-the-rules-we-know.tex
@@ -160,7 +160,11 @@ $$
 Two lists are equal if and only if they have the same length and the same elements in the same order.
 \end{definition}
 
-\begin{definition}{1.10}[$\F^n$]
+\begin{notation}{1.10}[notation: $n$]
+$n$ represents a positive integer.
+\end{notation}
+
+\begin{definition}{1.11}[$\F^n$, coordinate]
 $\F^n$ is the set of all lists of length $n$ of elements of $F$:
 $$
 \F^n = \{ (x_1, \ldots, x_n ) \setsep x_j \in \F \text{ for } j = 1, \ldots, n \}.
@@ -169,21 +173,21 @@ $$
 For $(x_1, \ldots, x_n ) \in \F^n$ and $j \in \{ 1, \ldots, n \}$, we say that $x_j$ is the $j^{\text{th}}$ \defn{coordinate} of $(x_1, \ldots, x_n )$.
 \end{definition}
 
-\begin{definition}{1.12}[addition in $F^n$]
+\begin{definition}{1.13}[addition in $F^n$]
 \defn{Addition} in $F^n$ is defined by adding corresponding coordinates:
 $$
 (x_1, \ldots, x_n ) + (y_1, \ldots, y_n ) = (x_1 + y_1, \ldots, x_n + y_n ).
 $$
 \end{definition}
 
-\begin{definition}{1.14}[$0$]
+\begin{definition}{1.15}[$0$]
 Let $0$ denote the list of length $n$ whose coorinates are all 0:
 $$
 (0, \ldots, 0 ).
 $$
 \end{definition}
 
-\begin{definition}{1.16}[additive inverse in $F^n$]
+\begin{definition}{1.17}[additive inverse in $F^n$]
 For $x \in \F^n$, the \defn{additive inverse} of $x$, denoted $-x$, is the vector $-x \in \F^n$ such that
 $$
 x + (-x) = 0.
@@ -191,7 +195,7 @@ $$
 In other words, if $x = (x_1, \ldots, x_n)$, then $-x = (-x_1, \ldots, -x_n)$.
 \end{definition}
 
-\begin{definition}{1.17}[scalar multiplication in $F^n$]
+\begin{definition}{1.18}[scalar multiplication in $F^n$]
 The \defn{product} of a number $\lambda$ and a vector in $\F^n$ is computed by multiplying each coordinate of the vector by $\lambda$:
 $$
 \lambda (x_1, \ldots, x_n) = (\lambda x_1, \ldots, \lambda x_n);
@@ -204,13 +208,13 @@ Here $\lambda \in \F$ and $(x_1, \ldots, x_n) \in \F^n$.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section*{Chapter 1.B}
 
-\begin{definition}{1.18}[addition, scalar multiplication]
+\begin{definition}{1.19}[addition, scalar multiplication]
 An \defn{addition} on a set $V$ is a function that assigns an element $u + v \in V$ to each pair of elements $u, v \in V$.
 
 A \defn{scalar multiplication} on a set $V$ is a function that assigns an element $\lambda v \in V$ to each $\lambda \in \F$ and each $v \in V$.
 \end{definition}
 
-\begin{definition}{1.19}[vector space]
+\begin{definition}{1.20}[vector space]
 A \defn{vector space over $\F$} is a set $V$ along with an addition on $V$ and a scalar multiplication on $V$ such that the following properties hold:
 
 \defn{commutativity}
@@ -244,17 +248,17 @@ $a (u + v) = au + av$ and $(a + b)v = av + bv$ for all $a, b \in \F$ and all $u,
 \end{forceindent}
 \end{definition}
 
-\begin{definition}{1.20}[vector, point]
+\begin{definition}{1.21}[vector, point]
 Elements of a vector space are called \defn{vectors} or \defn{points}.
 \end{definition}
 
-\begin{definition}{1.21}[real vector space, complex vector space]
+\begin{definition}{1.22}[real vector space, complex vector space]
 A vector space over $\R$ is called a \defn{real vector space}.
 
 A vector space over $\C$ is called a \defn{complex vector space}.
 \end{definition}
 
-\begin{notation}{1.23}[$\F^S$]
+\begin{notation}{1.24}[$\F^S$]
 If $S$ is a set, $\F^S$ denotes the set of functions from $S$ to $\F$.
 
 For $f, g \in \F^S$ the \defn{sum} $f + g \in \F^S$ is the function defined by
@@ -270,7 +274,7 @@ $$
 for all $x \in S$.
 \end{notation}
 
-\begin{notation}{1.27}[$-v, w - v$]
+\begin{notation}{1.28}[$-v, w - v$]
 Let $v, w \in V$. Then
 \begin{enumerate}
 \item $-v$ denotes the additive inverse of $v$;
@@ -278,29 +282,29 @@ Let $v, w \in V$. Then
 \end{enumerate}
 \end{notation}
 
-\begin{notation}{1.28}[$V$]
+\begin{notation}{1.29}[$V$]
 $V$ denotes a vector space over $\F$.
 \end{notation}
 
 The following rules can all derived from the definition of a vector space.
 
-\begin{result}{1.25}[Unique additive identity]
+\begin{result}{1.26}[Unique additive identity]
 A vector space has a unique additive identity.
 \end{result}
 
-\begin{result}{1.26}[Unique additive inverse]
+\begin{result}{1.27}[Unique additive inverse]
 Every element in a vector space has a unique additive inverse.
 \end{result}
 
-\begin{result}{1.29}[The number $0$ times a vector]
+\begin{result}{1.30}[The number $0$ times a vector]
 $0v = 0$ for every $v \in V$.
 \end{result}
 
-\begin{result}{1.30}[A number times the vector $0$]
+\begin{result}{1.31}[A number times the vector $0$]
 $a0 = 0$ for every $a \in \F$.
 \end{result}
 
-\begin{result}{1.31}[The number $-1$ times a vector]
+\begin{result}{1.32}[The number $-1$ times a vector]
 $(-1)v = -v$ for every $v \in V$.
 \end{result}
 


### PR DESCRIPTION
The numbering of the definitions, rules, etc. have changed in the fourth edition. This change updates the numbers to match.