### PR TITLE
Add manual trigger to the GitHub workflows

### DIFF
--- a/.github/workflows/pdflatex.yml
+++ b/.github/workflows/pdflatex.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - 'gh-action-result/pdf-files'
+  workflow_dispatch:
+
 jobs:
   build_latex:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a manual trigger, which can be useful if there are multiple branches each with different versions of the documentation available.

Triggering the workflow on a specific branch (which can be chosen when the build is run) will build and commit the PDF documents from the chosen branch, overwriting whatever was there previously.

To trigger: Actions > LaTeX build > Run workflow

Until this is merged it can't be tested from the alan-turing-institute version of the repo, but it can be tested from my fork: https://github.com/llewelld/hut23-linear-algebra/actions/workflows/pdflatex.yml