### PR TITLE
Rust matmul from Hackweek

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -80,7 +80,7 @@ cd matmul-racket
 racket matmul.rkt
 ```
 
-## Rust implementation
+## Rust implementation by Ed
 
 This is Ed Chapman's [Rust implementation](https://github.com/edchapman88/matrix_library) included as a submodule.
 Ensure the submodule has been updated and that Rust is available.
@@ -91,6 +91,17 @@ git submodule update --init
 cd matmul-rst
 cargo run --release
 ```
+
+## Rust implementation from Hackweek
+
+To run the improved Rust implementation developed during Hackweek, do
+
+```
+cd matmul-rst-hackweek
+cargo run --release
+```
+
+This is a much simplified and streamlined version of the Hackweek code we developed, which could handle tensors with arbitrary numbers of dimensions and do many things beside matmuls.
 
 ## R implementation
 

--- a/implementation/matmul-rst-hackweek/Cargo.toml
+++ b/implementation/matmul-rst-hackweek/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "matrix_library_hackweek"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[profile.release]
+opt-level = 3
+
+[dependencies]
+npyz = "0.8.3"
+float-cmp = "0.9.0"
+zip = "0.6.6"
+itertools = "0.12.1"
+anyhow = "1.0.86"
+num = "0.4.3"
+thiserror = "1.0.61"

--- a/implementation/matmul-rst-hackweek/src/lib.rs
+++ b/implementation/matmul-rst-hackweek/src/lib.rs
@@ -1,0 +1,216 @@
+use anyhow::Error;
+use num::traits::Zero;
+use std::{
+    cmp::{PartialEq, PartialOrd},
+    fmt::{Debug, Display},
+    ops::{Add, AddAssign, Div, Mul, Neg, Sub},
+    vec::Vec,
+};
+use thiserror::Error;
+
+// TODO This determines whether we transpose the second matrix first before multiplying. This
+// should pay off for large matrices, but I haven't tested what the actual threshold should be.
+const TRANSPOSE_THRESHOLD: usize = 1e9 as usize;
+
+pub trait AsAnyhowError: From<AsStdError> + Send + Sync {}
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct AsStdError(#[from] anyhow::Error);
+impl AsAnyhowError for AsStdError {}
+
+/// Matrix interface, generic over the the type of the elements contained within the matrix.
+/// The element type must be an implementer of `Element`.
+pub trait Matrix<E>: Clone
+where
+    E: Element,
+{
+    type MatrixError: Debug + AsAnyhowError + From<AsStdError> + From<anyhow::Error>;
+
+    fn from_vec(num_rows: usize, num_cols: usize, data: &Vec<E>)
+        -> Result<Self, Self::MatrixError>;
+
+    fn transpose(&self) -> Self;
+
+    fn matmul(&self, other: &Self) -> Self;
+}
+
+/// Collection of traits required by the elements of a Matrix.
+pub trait Element:
+    Debug
+    + Clone
+    + PartialEq
+    + Display
+    + Add<Output = Self>
+    + AddAssign
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Zero
+{
+}
+
+// Below are some implementations of `Element` and `RealElement` "for free". This should facilitate
+// unit testing with these types.
+impl Element for usize {}
+impl Element for u32 {}
+impl Element for u16 {}
+impl Element for i32 {}
+impl Element for f64 {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatrixImpl<E>
+where
+    E: Element,
+{
+    pub num_cols: usize,
+    pub num_rows: usize,
+    data: Vec<E>,
+}
+
+impl<E> MatrixImpl<E>
+where
+    E: Element + PartialOrd + Neg<Output = E>,
+{
+    pub fn compare(&self, other: &Self, tolerance: E) -> bool {
+        if self.num_cols != other.num_cols || self.num_rows != other.num_rows {
+            return false;
+        }
+        let neg_tolerance = -tolerance.clone();
+        for i in 0..self.data.len() {
+            let diff = self.data[i].clone() - other.data[i].clone();
+            if (tolerance < diff) || (diff < neg_tolerance) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+impl<E: Element> MatrixImpl<E> {
+    /// Multiply self by the transpose of a matrix.
+    ///
+    /// This is equivalent to `self.matmul(other.transpose())`, but faster.
+    fn matmul_transpose(&self, other: &Self) -> MatrixImpl<E> {
+        debug_assert!(self.num_cols != other.num_cols);
+        let dim1 = self.num_rows;
+        let dim_inner = self.num_cols;
+        let dim2 = other.num_rows;
+        // Create an unallocated data vector for the result.
+        let n_elements = dim1 * dim2;
+        let mut new_data: Vec<E> = Vec::with_capacity(n_elements);
+
+        // Loop over the elements in the order of new_data.
+        for j1 in 0..dim1 {
+            let idx1 = j1 * dim_inner;
+            for j2 in 0..dim2 {
+                let idx2 = j2 * dim_inner;
+                let mut accumulator = E::zero();
+                for j_inner in 0..dim_inner {
+                    let self_idx = idx1 + j_inner;
+                    let other_idx = idx2 + j_inner;
+                    //let other_idx = j2 + j_inner * dim2;
+                    accumulator += unsafe {
+                        self.data.get_unchecked(self_idx).clone()
+                            * other.data.get_unchecked(other_idx).clone()
+                    };
+                }
+                new_data.push(accumulator);
+            }
+        }
+        return MatrixImpl {
+            num_rows: dim1,
+            num_cols: dim2,
+            data: new_data,
+        };
+    }
+
+    /// Multiply self by a matrix.
+    fn matmul_straight(&self, other: &Self) -> MatrixImpl<E> {
+        debug_assert!(self.num_cols != other.num_rows);
+        let dim1 = self.num_rows;
+        let dim_inner = self.num_cols;
+        let dim2 = other.num_cols;
+        // Create an unallocated data vector for the result.
+        let n_elements = dim1 * dim2;
+        let mut new_data: Vec<E> = Vec::with_capacity(n_elements);
+
+        // Loop over the elements in the order of new_data.
+        for j1 in 0..dim1 {
+            let idx1 = j1 * dim_inner;
+            for j2 in 0..dim2 {
+                let mut accumulator = E::zero();
+                for j_inner in 0..dim_inner {
+                    let self_idx = idx1 + j_inner;
+                    let other_idx = j2 + j_inner * dim2;
+                    accumulator += unsafe {
+                        self.data.get_unchecked(self_idx).clone()
+                            * other.data.get_unchecked(other_idx).clone()
+                    };
+                }
+                new_data.push(accumulator);
+            }
+        }
+        return MatrixImpl {
+            num_rows: dim1,
+            num_cols: dim2,
+            data: new_data,
+        };
+    }
+}
+
+impl<E> Matrix<E> for MatrixImpl<E>
+where
+    E: Element,
+{
+    type MatrixError = AsStdError;
+
+    fn from_vec(
+        num_rows: usize,
+        num_cols: usize,
+        data: &Vec<E>,
+    ) -> Result<Self, Self::MatrixError> {
+        if num_rows * num_cols != data.len() {
+            return Err(
+                Error::msg("The length of the `data` param does not match the dimensions").into(),
+            );
+        } else {
+            Ok(MatrixImpl {
+                num_rows: num_rows,
+                num_cols: num_cols,
+                data: data.clone(),
+            })
+        }
+    }
+
+    fn transpose(&self) -> Self {
+        let dim0 = self.num_rows;
+        let dim1 = self.num_cols;
+        // Create an unallocated data vector the same size as the original.
+        let n_elements = dim0 * dim1;
+        let mut new_data: Vec<E> = Vec::with_capacity(n_elements);
+
+        // Loop over the elements in the order of new_data.
+        for j in 0..dim1 {
+            for k in 0..dim0 {
+                // Find the data index of this element in the original matrix.
+                // Note the reversal of the roles of k an j.
+                let transposed_idx = k * dim1 + j;
+                new_data.push(self.data[transposed_idx].clone());
+            }
+        }
+        return MatrixImpl {
+            num_rows: dim1,
+            num_cols: dim0,
+            data: new_data,
+        };
+    }
+
+    fn matmul(&self, other: &Self) -> Self {
+        if self.num_cols * self.num_rows * other.num_rows > TRANSPOSE_THRESHOLD {
+            return self.matmul_transpose(&other.transpose());
+        } else {
+            return self.matmul_straight(&other);
+        }
+    }
+}

--- a/implementation/matmul-rst-hackweek/src/lib.rs
+++ b/implementation/matmul-rst-hackweek/src/lib.rs
@@ -96,7 +96,7 @@ impl<E: Element> MatrixImpl<E> {
         let dim1 = self.num_rows;
         let dim_inner = self.num_cols;
         let dim2 = other.num_rows;
-        // Create an unallocated data vector for the result.
+        // Create an uninitialised data vector for the result.
         let n_elements = dim1 * dim2;
         let mut new_data: Vec<E> = Vec::with_capacity(n_elements);
 
@@ -131,7 +131,7 @@ impl<E: Element> MatrixImpl<E> {
         let dim1 = self.num_rows;
         let dim_inner = self.num_cols;
         let dim2 = other.num_cols;
-        // Create an unallocated data vector for the result.
+        // Create an uninitialised data vector for the result.
         let n_elements = dim1 * dim2;
         let mut new_data: Vec<E> = Vec::with_capacity(n_elements);
 

--- a/implementation/matmul-rst-hackweek/src/load.rs
+++ b/implementation/matmul-rst-hackweek/src/load.rs
@@ -1,0 +1,130 @@
+use core::iter::zip;
+use itertools::izip;
+use matrix_library_hackweek::{Matrix, MatrixImpl};
+use npyz::NpyFile;
+use std::error::Error;
+use std::fs::File;
+use std::io;
+use std::time::Instant;
+
+const BENCHMARK_REPEAT: usize = 32768;
+
+// Load an npy file as a Matrix
+pub fn load(filename: &str) -> Result<MatrixImpl<f64>, Box<dyn std::error::Error>> {
+    let bytes = std::fs::read(filename)?;
+    let npy = npyz::NpyFile::new(&bytes[..])?;
+    read(npy)
+}
+
+// Convert an npy input stream into a Matrix
+fn read<R: std::io::Read>(npy: NpyFile<R>) -> Result<MatrixImpl<f64>, Box<dyn std::error::Error>> {
+    let shape: Vec<usize> = npy.shape().iter().map(| &i | i as usize).collect();
+    let data: Vec<f64> = npy.data::<f64>().unwrap().into_iter().map(| d | d.unwrap()).collect();
+    Ok(MatrixImpl::from_vec(shape[0], shape[1], &data).unwrap())
+}
+
+// Neat approach by budziq from rust-lang.org
+// See https://users.rust-lang.org/t/how-to-parse-an-int-from-string/12456/12
+fn parse_int(input: &str) -> Option<u32> {
+    input
+        .chars()
+        .skip_while(|ch| !ch.is_digit(10))
+        .take_while(|ch| ch.is_digit(10))
+        .fold(None, |acc, ch| {
+            ch.to_digit(10).map(|b| acc.unwrap_or(0) * 10 + b)
+        })
+}
+
+// Load in the test data from the npz file
+fn load_tests(
+    filename: &str,
+) -> Result<
+    (
+        Vec<MatrixImpl<f64>>,
+        Vec<MatrixImpl<f64>>,
+        Vec<MatrixImpl<f64>>,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let mut a = Vec::<MatrixImpl<f64>>::new();
+    let mut b = Vec::<MatrixImpl<f64>>::new();
+    let mut c = Vec::<MatrixImpl<f64>>::new();
+
+    println!("Reading test matrices from file");
+
+    let file = io::BufReader::new(File::open(filename)?);
+
+    let mut zip = zip::ZipArchive::new(file)?;
+
+    for i in 0..zip.len() {
+        let file = zip.by_index(i)?;
+        let name = file.name();
+        let prefix = file.name().chars().next();
+        let num: usize = parse_int(name).unwrap().try_into().unwrap();
+        let npy = NpyFile::new(file)?;
+        let matrix = read(npy)?;
+        match prefix {
+            Some('a') => a.insert(num, matrix.clone()),
+            Some('b') => b.insert(num, matrix.clone()),
+            Some('c') => c.insert(num, matrix.clone()),
+            Some(_) => println!("Error"),
+            None => println!("Error"),
+        }
+    }
+
+    Ok((a, b, c))
+}
+
+// Run simple unit and benchmarking tests
+pub fn run_tests() -> Result<(), Box<dyn Error>> {
+    println!("Example matrix manipulation...");
+    let a = load("../testdata/matrix-a.npy")?;
+    let b = load("../testdata/matrix-b.npy")?;
+    let c = load("../testdata/matrix-c.npy")?;
+
+    let d = a.matmul(&b);
+    let result = c.compare(&d, 1e-10);
+
+    println!("Result of A * B:");
+    println!("Size: {}, {}", d.num_rows, d.num_cols);
+
+    println!(
+        "Matches expected result: {}",
+        if result { "Yes" } else { "No" }
+    );
+
+    // Perform 512 multiplications and compare against the results from NumPy
+    println!("Performing unit tests...");
+    let (a, b, c) = load_tests("../testdata/matrices.npz")?;
+
+    let total = a.len();
+    let mut passed = 0;
+    for (mata, matb, matc) in izip!(&a, &b, &c) {
+        let matd = mata.matmul(&matb);
+        if matc.compare(&matd, 1e-10) {
+            passed += 1;
+        } else {
+            println!("Incorrect result");
+        }
+    }
+    println!("Multiplication tests passed: {} out of {}", passed, total);
+
+    println!("Benchmarking...");
+    let start_time = Instant::now();
+    for _count in 0..BENCHMARK_REPEAT {
+        for (mata, matb) in zip(&a, &b) {
+            let _matd = mata.matmul(&matb);
+        }
+    }
+    let elapsed = start_time.elapsed();
+    let operations = total * BENCHMARK_REPEAT;
+    println!(
+        "Time taken to perform {} multiply operations: {:.02} seconds\n",
+        operations,
+        elapsed.as_millis() as f64 / 1000.0
+    );
+    let ops_per_sec: f64 = 1000.0 * operations as f64 / elapsed.as_millis() as f64;
+    println!("Equivalent to {:.02} operations per second", ops_per_sec);
+
+    Ok(())
+}

--- a/implementation/matmul-rst-hackweek/src/main.rs
+++ b/implementation/matmul-rst-hackweek/src/main.rs
@@ -1,0 +1,7 @@
+use std::error::Error;
+
+mod load;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    load::run_tests()
+}


### PR DESCRIPTION
I simplified the tensor code we wrote in Rust during the hackweek, removing everything about multidimensional arrays and everything that wasn't serving the purpose of multiplying matrices, and turned it into a benchmark competitor.